### PR TITLE
feat: Added mechanic to query application information from backend

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,6 +18,15 @@ mod connection;
 mod verify;
 mod errors;
 
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[tauri::command]
+async fn get_ballista_info() -> String {
+    let mut obj = serde_json::Map::new();
+    obj.insert("ballista_version".to_string(), serde_json::Value::String(String::from(APP_VERSION)));
+    return serde_json::to_string(&obj).unwrap()
+}
+
 #[tauri::command(rename_all = "snake_case")]
 fn launch(id: &str, cs: State<ConnectionStore>, wc: State<WebStartCache>) -> String {
     let ce = cs.get(id);
@@ -28,7 +37,7 @@ fn launch(id: &str, cs: State<ConnectionStore>, wc: State<WebStartCache>) -> Str
             if let Err(e) = tmp {
                 let msg = e.to_string();
                 println!("{}", msg);
-                return  create_json_resp(-1, &msg);
+                return create_json_resp(-1, &msg);
             }
 
             ws = Some(Arc::new(tmp.unwrap()));
@@ -46,7 +55,7 @@ fn launch(id: &str, cs: State<ConnectionStore>, wc: State<WebStartCache>) -> Str
         if let Err(e) = r {
             let msg = e.to_string();
             println!("{}", msg);
-            return  create_json_resp(-1, &msg);
+            return create_json_resp(-1, &msg);
         }
     }
 
@@ -125,7 +134,7 @@ fn main() {
     tauri::Builder::default()
         .manage(cs.unwrap())
         .manage(wc)
-        .invoke_handler(tauri::generate_handler![launch, import, delete, save, load_connections, trust_cert])
+        .invoke_handler(tauri::generate_handler![launch, import, delete, save, load_connections, trust_cert, get_ballista_info])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import {
     searchText
 } from './connection';
 import Search from "antd/es/input/Search";
+import {BallistaInfo, requestBallistaInfo} from "./ballistaInfo";
 
 const { Content, Sider } = Layout;
 
@@ -97,6 +98,8 @@ function App() {
     const [groupNames, setGroupNames] = useState([DEFAULT_GROUP_NAME]);
     const groupInputRef = useRef<InputRef>(null); // for the group name selection
 
+    const [ballistaInfo, setBallistaInfo] = useState<BallistaInfo>();
+
     const emptyConnection: Connection = {
         address: "",
         heapSize: "",
@@ -124,6 +127,11 @@ function App() {
         expires_on: undefined
     });
     const [loading, setLoading] = useState(false);
+
+    useEffect(() => {requestBallistaInfo().then(data => {
+        setBallistaInfo(data)
+        appWindow.setTitle(`Ballista - ${data.ballista_version}`)
+    })}, [])
 
     useEffect(() => {loadConnections().then(d => {
         setData(d);

--- a/src/ballistaInfo.ts
+++ b/src/ballistaInfo.ts
@@ -1,0 +1,11 @@
+import {invoke} from "@tauri-apps/api/tauri";
+
+export interface BallistaInfo {
+    ballista_version: string
+}
+
+export async function requestBallistaInfo() {
+    console.log("requesting ballista info");
+    const jsonArr: string = await invoke("get_ballista_info");
+    return JSON.parse(jsonArr)
+}


### PR DESCRIPTION
Added mechanic to query application information from backend.
Included a new interface `BallistaInfo` to information about the app. Currently only houses `ballista_version` field.

Also added the current app version into window title.