### PR TITLE
Add additional Java args capability

### DIFF
--- a/src-tauri/src/connection.rs
+++ b/src-tauri/src/connection.rs
@@ -25,6 +25,8 @@ pub struct ConnectionEntry {
     pub id: String,
     #[serde(rename = "javaHome")]
     pub java_home: String,
+    #[serde(rename = "javaArgs")]
+    pub java_args: Option<String>,
     pub name: String,
     pub username: Option<String>,
     pub password: Option<String>,
@@ -55,6 +57,7 @@ impl Default for ConnectionEntry {
             icon: empty_str.clone(),
             id: Uuid::new_v4().to_string(),
             java_home: find_java_home(),
+            java_args: Option::from(empty_str.clone()),
             name: empty_str.clone(),
             username: None,
             password: None,

--- a/src-tauri/src/webstart.rs
+++ b/src-tauri/src/webstart.rs
@@ -198,24 +198,9 @@ impl WebstartFile {
             cmd.arg(format!("-Xmx{}", heap));
         }
 
-        if let Ok(port) = env::var("debugport") {
-            let port = port.parse::<u32>();
-            if let Err(e) = port {
-                let msg = format!("invalid debug port number {}", e);
-                return Err(anyhow::anyhow!(msg));
-            }
-
-            let port = port.unwrap();
-            let mut suspend = env::var("suspend").map_or(String::from("n"), |s| s);
-            if(suspend != "n") {
-                suspend = String::from("y");
-            }
-
-            println!("enabling debugging at port {} with suspend flag set to {}", port, suspend);
-            cmd.arg("-Xdebug");
-            cmd.arg("-Xnoagent");
-            cmd.arg("-Djava.compiler=NONE");
-            cmd.arg(format!("-Xrunjdwp:transport=dt_socket,server=y,suspend={},address={}", suspend, port));
+        if let Some(args) = ce.java_args.as_deref() {
+            // Should probably do some sanitization here...
+            cmd.args(args.trim().lines());
         }
 
         cmd.arg("-cp")


### PR DESCRIPTION
The PR adds a field to the `Connection` struct to optionally house additional new-line separated JVM arguments. Those arguments are then passed on to the administrator UI JVM.

I've not added UI elements in this PR as i'm doing a small touch-up in another branch and would not like to spend time on it here.