### PR TITLE
Remove NSStatusItem

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 tauri-build = { version = "2.5.5", features = [] }
 
 [dependencies]
-tauri = { version = "2.10.2", features = ["tray-icon"] }
+tauri = { version = "2.10.2", features = [] }
 tauri-runtime-wry = "2.10.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,10 +24,6 @@
   "plugins": {},
   "app": {
     "withGlobalTauri": false,
-    "trayIcon": {
-      "iconPath": "icons/icon.png",
-      "title": "Ballista"
-    },
     "security": {
       "csp": null
     },


### PR DESCRIPTION
Removes the notification icon on windows / NSStatusItem on mac that doesn't seem to do anything.

Closes #40 