### PR TITLE
Use OS theme by default

### DIFF
--- a/app/composables/useTheme.ts
+++ b/app/composables/useTheme.ts
@@ -9,17 +9,50 @@ const STORAGE_KEY = "ballista-theme"
 const DEFAULT_THEME: Theme = "dark"
 
 const theme = ref<Theme>(DEFAULT_THEME)
+let systemThemeListenerRegistered = false
+
+function getSystemThemeMediaQuery() {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)")
+}
+
+function getSystemTheme(): Theme {
+  const mediaQuery = getSystemThemeMediaQuery()
+  if (!mediaQuery) {
+    return DEFAULT_THEME
+  }
+
+  return mediaQuery.matches ? "dark" : "light"
+}
 
 function applyTheme(t: Theme) {
   theme.value = t
   document.documentElement.setAttribute("data-theme", t)
+  document.documentElement.style.colorScheme = t
   localStorage.setItem(STORAGE_KEY, t)
 }
 
 export function useTheme() {
   function init() {
     const saved = localStorage.getItem(STORAGE_KEY) as Theme | null
-    applyTheme(saved === "light" ? "light" : DEFAULT_THEME)
+    applyTheme(saved === "light" ? "light" : getSystemTheme());
+
+    if (systemThemeListenerRegistered) {
+      return
+    }
+
+    const mediaQuery = getSystemThemeMediaQuery()
+    if (!mediaQuery) {
+      return
+    }
+
+    mediaQuery.addEventListener("change", (event) => {
+      applyTheme(event.matches ? "dark" : "light")
+    })
+    systemThemeListenerRegistered = true
   }
 
   function toggle() {


### PR DESCRIPTION
Master seems to default to dark mode.  Respecting the OS default is a standard practice for windows and Mac, and also will follow the default when changed throughout the day.  Does not prevent manual override.